### PR TITLE
Replace 'inline' with 'static inline'

### DIFF
--- a/src/mcu-renderer/mcu-renderer.c
+++ b/src/mcu-renderer/mcu-renderer.c
@@ -229,13 +229,13 @@ static inline mr_point_t mr_rotate_point(mr_t *mr,
 
 #endif
 
-inline int16_t mr_min(int16_t a,
+static inline int16_t mr_min(int16_t a,
                       int16_t b)
 {
     return (a < b) ? a : b;
 }
 
-inline int16_t mr_max(int16_t a,
+static inline int16_t mr_max(int16_t a,
                       int16_t b)
 {
     return (a > b) ? a : b;

--- a/src/mcu-renderer/mcu-renderer.h
+++ b/src/mcu-renderer/mcu-renderer.h
@@ -209,17 +209,17 @@ struct mr_t_
 
 void mr_init(mr_t *mr);
 
-inline void mr_set_command(mr_t *mr, bool value)
+static inline void mr_set_command(mr_t *mr, bool value)
 {
     mr->set_command_callback(value);
 }
 
-inline void mr_send(mr_t *mr, uint8_t value)
+static inline void mr_send(mr_t *mr, uint8_t value)
 {
     mr->send_callback(value);
 }
 
-inline void mr_send16(mr_t *mr, uint16_t value)
+static inline void mr_send16(mr_t *mr, uint16_t value)
 {
     mr->send16_callback(value);
 }


### PR DESCRIPTION
This change enables compilers to correctly scope the symbol and apply inlining optimizations. For example, clang emits functions and calls in the code, which is suboptimal. By assisting the compiler, we ensure that this function, not used elsewhere, does not need global scope. Without this modification, the project cannot be built on macOS, where Clang is the default compiler.