### PR TITLE
fontconv on linux

### DIFF
--- a/tools/fontconv/BitWriter.cpp
+++ b/tools/fontconv/BitWriter.cpp
@@ -7,7 +7,7 @@
  * License: MIT
  */
 
-#include "bitwriter.h"
+#include "BitWriter.h"
 
 BitWriter::BitWriter()
 {

--- a/tools/fontconv/Font.cpp
+++ b/tools/fontconv/Font.cpp
@@ -7,6 +7,8 @@
  * License: MIT
  */
 
+#include <climits>
+
 #include "Font.h"
 
 MinMax::MinMax()

--- a/tools/fontconv/encode.h
+++ b/tools/fontconv/encode.h
@@ -10,8 +10,8 @@
 #if !defined(ENCODER_H)
 #define ENCODER_H
 
-#include "font.h"
-#include "bitwriter.h"
+#include "Font.h"
+#include "BitWriter.h"
 
 void encodeFont(Font &font,
                 uint32_t bitsPerPixel,

--- a/tools/fontconv/export.h
+++ b/tools/fontconv/export.h
@@ -10,7 +10,7 @@
 #if !defined(EXPORT_C_H)
 #define EXPORT_C_H
 
-#include "font.h"
+#include "Font.h"
 
 void exportFont(Font &font,
                  std::string variableName,

--- a/tools/fontconv/import_bdf.cpp
+++ b/tools/fontconv/import_bdf.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdlib>
 #include <fstream>
+#include <climits>
 
 #include "import_bdf.h"
 #include "utils.h"

--- a/tools/fontconv/import_bdf.h
+++ b/tools/fontconv/import_bdf.h
@@ -14,7 +14,7 @@
 #include <set>
 #include <string>
 
-#include "font.h"
+#include "Font.h"
 
 Font loadBDFFont(std::string filename,
                  std::set<Charcode> &charcodeSet);

--- a/tools/fontconv/import_freetype.h
+++ b/tools/fontconv/import_freetype.h
@@ -13,8 +13,9 @@
 #include <cstdint>
 #include <set>
 #include <string>
+#include <climits>
 
-#include "font.h"
+#include "Font.h"
 
 Font loadFreeTypeFont(std::string filename,
                       std::set<Charcode> &charcodeSet,


### PR DESCRIPTION
This patch is needed to build fontconv on linux. 

Also, examples/helloworld-sdl/CMakeLists.txt needs to be looked at. At least add
```
find_package(SDL2 CONFIG REQUIRED)
 
+include_directories(${SDL2_INCLUDE_DIRS})
+
 add_definitions(-D MCURENDERER_SDL)
```

HTH