### PR TITLE
fontconv: include characters from text file

### DIFF
--- a/examples/arduino/helloworld-stm32-st7789/display.cpp
+++ b/examples/arduino/helloworld-stm32-st7789/display.cpp
@@ -46,7 +46,7 @@ void on_display_set_reset(bool value)
   digitalWrite(DISPLAY_RESX, !value);
 }
 
-void on_display_set_reset(bool value)
+void on_display_set_chipselect(bool value)
 {
   digitalWrite(DISPLAY_CSX, !value);
 }

--- a/tools/fontconv/main.cpp
+++ b/tools/fontconv/main.cpp
@@ -29,6 +29,7 @@ void printHelp(void)
          << "-p <size>   Set point size for rasterizing fonts (default: " << DEFAULT_POINT_SIZE << ").\n"
          << "-b <size>   Set bits per pixel (default: " << DEFAULT_BITS_PER_PIXEL << ").\n"
          << "-s <subset> Specify a subset of Unicode characters to convert.\n"
+         << "-u <filename> Specify a text file with utf8 characters to convert.\n"
          << "-c <size>   Override the font cap height.\n"
          << "-a <size>   Override the font ascent (baseline to top of line).\n"
          << "-d <size>   Override the font descent (bottom of line to baseline).\n"
@@ -56,6 +57,7 @@ int main(int argc, char **argv)
     string variableName;
     string inputFilename;
     string outputFilename;
+    string textFilename;
 
     for (uint32_t i = 0; i < args.size(); i++)
     {
@@ -121,6 +123,13 @@ int main(int argc, char **argv)
             if (i < args.size())
                 variableName = args[i];
         }
+        else if (args[i].compare("-u") == 0)
+        {
+            i++;
+
+            if (i < args.size())
+                textFilename = args[i];
+        }
         else if (inputFilename == "")
             inputFilename = args[i];
         else if (outputFilename == "")
@@ -139,6 +148,9 @@ int main(int argc, char **argv)
         Font font;
 
         set<Charcode> charcodeSet = parseCharcodes(charcodes);
+
+        if (!textFilename.empty())
+            charcodeSet.merge(parseUtf8(textFilename));
 
         if (to_lower(inputFilename).ends_with(".bdf"))
         {

--- a/tools/fontconv/utils.cpp
+++ b/tools/fontconv/utils.cpp
@@ -9,6 +9,8 @@
 
 #include <stdexcept>
 #include <string>
+#include <iostream>
+#include <fstream>
 
 using namespace std;
 
@@ -95,5 +97,72 @@ set<Charcode> parseCharcodes(string &charcodes)
         }
     }
 
+    return charcodeSet;
+}
+
+set<Charcode> parseUtf8(string &filename)
+{
+    const bool utf8_verbose = false;
+    set<Charcode> charcodeSet;
+    uint8_t byte;
+    int glyph;
+    int more_bytes;
+    int utf8_errs = 0; 
+
+    ifstream file(filename, ios::in | ios::binary);
+    if (!file.good())
+        throw runtime_error("could not open '" +
+                            filename +
+                            "'");
+
+    while (file.read(reinterpret_cast<char*>(&byte), 1)) {
+        glyph = 0;
+        more_bytes = 0;
+        
+        if (byte <= 0x7F) {
+        glyph = byte;
+        more_bytes = 0;
+        } else if ((byte & 0xE0) == 0xC0) {
+            glyph = byte & 0x1F;
+            more_bytes = 1;
+        } else if ((byte & 0xF0) == 0xE0) {
+            glyph = byte & 0x0F;
+            more_bytes = 2;
+        } else if ((byte & 0xF8) == 0xF0) {
+            glyph = byte & 0x07;
+            more_bytes = 3;
+        } else if ((byte & 0xFC) == 0xF8) {
+            glyph = byte & 0x03;
+            more_bytes = 4;
+        } else if ((byte & 0xFE) == 0xFC) {
+            glyph = byte & 0x01;
+            more_bytes = 5;
+        } else {
+            if (utf8_verbose)
+                cerr << "? 0x" << hex << byte << endl;
+            utf8_errs++;
+            continue;
+        }
+        while (more_bytes > 0) {
+            if (!file.read(reinterpret_cast<char*>(&byte), 1))
+                break;
+            if ((byte & 0xC0) != 0x80) {
+                utf8_errs++;
+                break;
+            }
+            glyph = (glyph << 6) | (byte & 0x3F);
+            --more_bytes;
+        }
+        if (more_bytes == 0) {
+            if (utf8_verbose)
+                cerr << "add 0x" << hex << glyph << endl;
+            charcodeSet.insert(glyph); /* add glyph to font */
+        }
+    }
+
+    if (utf8_errs != 0)
+        cerr << utf8_errs << "utf8 errors" << endl;
+
+    file.close();
     return charcodeSet;
 }

--- a/tools/fontconv/utils.h
+++ b/tools/fontconv/utils.h
@@ -19,5 +19,6 @@ std::string to_lower(std::string str);
 std::string to_upper(std::string str);
 std::vector<std::string> split(std::string &str, char c);
 std::set<Charcode> parseCharcodes(std::string &charcodes);
+std::set<Charcode> parseUtf8(std::string &filename);
 
 #endif


### PR DESCRIPTION
This PR adds an option to fontconv to include characters from a text file in utf8.  This is useful for a program like [Marlin](https://marlinfw.org/docs/development/lcd_language.html), which has menus in various languages. As an example, assume all ui text messages are in a header file text.h in utf8 format.
 - download [gnu unifont](https://www.unifoundry.com/unifont/), e.g. in bdf format.
 - run `fontconv -s 0x20-0x7e -u text.h unifont-16.0.02.bdf unifont.h`
 - use header file unifont.h in your program
 
Other issues:
Fixed a typo in the arduino example.
Also, I am using a ili9341 display from [WeAct](https://aliexpress.com/item/1005005183119266.html). mcu-renderer output on this display is mirrored. To fix this, I had to set madctl to MR_ST7789_MADCTL_MV. 

![mr](https://github.com/user-attachments/assets/ed65c3b4-454c-4c11-9b02-5fc371ed6fe5)
