### PR TITLE
Fix missing static on inline callback wrappers in mcu-renderer.h

### DIFF
--- a/src/mcu-renderer.h
+++ b/src/mcu-renderer.h
@@ -250,22 +250,22 @@ struct mr_t_
 
 void mr_init(mr_t *mr);
 
-inline void mr_set_chipselect(mr_t *mr, bool value)
+static inline void mr_set_chipselect(mr_t *mr, bool value)
 {
     mr->set_chipselect_callback(value);
 }
 
-inline void mr_set_command(mr_t *mr, bool value)
+static inline void mr_set_command(mr_t *mr, bool value)
 {
     mr->set_command_callback(value);
 }
 
-inline void mr_send(mr_t *mr, uint8_t value)
+static inline void mr_send(mr_t *mr, uint8_t value)
 {
     mr->send_callback(value);
 }
 
-inline void mr_send16(mr_t *mr, uint16_t value)
+static inline void mr_send16(mr_t *mr, uint16_t value)
 {
     mr->send16_callback(value);
 }


### PR DESCRIPTION
## Problem

`mr_set_chipselect`, `mr_set_command`, `mr_send` and `mr_send16` in `src/mcu-renderer.h` are defined as plain `inline` instead of `static inline`. Under C99 inline semantics, a plain `inline` function definition in a header does not guarantee an out-of-line definition is emitted anywhere in the program. At `-O0` (no inlining), the compiler may not emit a definition at all, leaving only external references — which causes `undefined reference` link errors for any consumer built without optimization.

This is a regression of the fix already applied in #1, which changed `mr_set_command`/`mr_send`/`mr_send16` (and `mr_min`/`mr_max`) from `inline` to `static inline` for exactly this reason. The 2024-04-29 "Arduino compatibility" rewrite that flattened the library into its current file layout silently reintroduced plain `inline` for those three functions, and `mr_set_chipselect` was added later (2.1beta3) using the same broken pattern. Note `mr_min`/`mr_max` in `src/mcu-renderer.c` are still correctly `static inline` today, confirming this is an unintentional regression rather than a deliberate style change.

## Reproduction

Compiled the unmodified `src/mcu-renderer.c` + `src/mcu-renderer-st7565.c` against a small test `main.c` calling `mr_st7565_init`/`mr_st7565_refresh_display`, with `gcc 8.1.0 -O0 -std=c99`:

```
mcu-renderer.o: undefined reference to `mr_set_command'
mcu-renderer.o: undefined reference to `mr_send'
mcu-renderer.o: undefined reference to `mr_set_chipselect'
mcu-renderer-st7565.o: undefined reference to `mr_set_chipselect'
mcu-renderer-st7565.o: undefined reference to `mr_set_command'
collect2.exe: error: ld returned 1 exit status
```

At `-O2` the same original files link and run fine, which is presumably why this has gone unnoticed — it only bites debug/no-optimization builds.

## Fix

Change `inline` to `static inline` on the four function definitions (`mr_set_chipselect`, `mr_set_command`, `mr_send`, `mr_send16`), mirroring #1. With the fix applied, the identical `.c` files link successfully at `-O0 -std=c99` and the resulting binary runs to completion.

No other changes.